### PR TITLE
fix for saml state null check

### DIFF
--- a/modules/core/lib/Auth/Process/AttributeLimit.php
+++ b/modules/core/lib/Auth/Process/AttributeLimit.php
@@ -67,7 +67,7 @@ class sspmod_core_Auth_Process_AttributeLimit extends SimpleSAML_Auth_Processing
 		if(array_key_exists('AttributeConsumingService', $request['Destination'])) {
 
 			// if present, get AttributeConsumingServiceIndex from request
-			if(array_key_exists('saml:AttributeConsumingServiceIndex',$request)) {
+			if(array_key_exists('saml:AttributeConsumingServiceIndex',$request) && !is_null($request['saml:AttributeConsumingServiceIndex'])) {
 				$acsi = $request['saml:AttributeConsumingServiceIndex'];
 
 				// if index from request exists in the configuration, return corresponding attributes

--- a/tests/modules/core/lib/Auth/Process/AttributeLimitTest.php
+++ b/tests/modules/core/lib/Auth/Process/AttributeLimitTest.php
@@ -437,6 +437,44 @@ class Test_Core_Auth_Process_AttributeLimitTest extends PHPUnit_Framework_TestCa
     }
 
     /**
+     * Test default AttributeConsumingServiceIndex in SP metadata
+     * when saml:AttributeConsumingServiceIndex is null
+     */
+
+    public function testAttributeConsumingServiceNULLDefault()
+    {
+        // default config
+        $config = array(
+        );
+
+        //prepare request without AttributeConsumingServiceIndex
+        $request = array(
+            'Attributes' => array(
+                 'eduPersonPrincipalName' => array('eptid@example.org'),
+                 'eduPersonAffiliation' => array('member'),
+                 'cn' => array('user name'),
+                 'mail' => array('user@example.org'),
+                 'testN1' => array('testV1'),
+                 'testN2' => array('testV2'),
+                 'testN3' => array('testV3'),
+             ),
+            'Destination' => array(
+                'AttributeConsumingService' => self::$attributeConsumingService,
+                'AttributeConsumingService.default' => 0,
+             ),
+            'Source' => array(
+             ),
+             'saml:AttributeConsumingServiceIndex' => null,
+        );
+
+        $result = self::processFilter($config, $request);
+        $attributes = $result['Attributes'];
+        $this->assertArrayHasKey('eduPersonPrincipalName', $attributes);
+        $this->assertArrayHasKey('mail', $attributes);
+        $this->assertCount(2, $attributes);
+    }
+
+    /**
      * Test default AttributeConsumingServiceIndex not in SP metadata.
      *
      * @expectedException Exception 


### PR DESCRIPTION
added check if saml:AttributeConsumingServiceIndex is present and is null